### PR TITLE
Small improvement to text on GH edit link

### DIFF
--- a/themes/learn2/languages.yaml
+++ b/themes/learn2/languages.yaml
@@ -1,6 +1,6 @@
 en:
     THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: edit this page on Github
-    THEME_LEARN2_GITHUB_NOTE: Found errors? Think you can improve this documentation? Prefer code to UI?
+    THEME_LEARN2_GITHUB_NOTE: Found errors? Think you can improve this documentation? 
     THEME_LEARN2_CLEAR_HISTORY: Clear History
     THEME_LEARN2_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
     THEME_LEARN2_SEARCH_DOCUMENTATION: Search Documentation


### PR DESCRIPTION
The text on the Github edit text was unclear, so this is a very small update to remove the confusion