### PR TITLE
Add info about plain text email auto-generation

### DIFF
--- a/pages/07.Channels/02.Emails/01.Managing emails/docs.en.md
+++ b/pages/07.Channels/02.Emails/01.Managing emails/docs.en.md
@@ -56,6 +56,7 @@ Email Builder has also special tokens for the Unsubscribe link, Webview link and
 - `{webview_url}` - Creates a URL to the webview page which can be used in a link's href attribute.
 - `{tracking_pixel}` - Creates a 1 pixel image that allows to track email open.
 
+Since Mautic 3.1, a plain-text version of emails will be created when sent if one is not provided during the creation process.
 
 ### Contact token modifiers
 


### PR DESCRIPTION
Add info to resolve #103 explaining that a plain-text version will be auto-generated if not provided.