### PR TITLE
Remove doctrine:schema:update step

### DIFF
--- a/pages/03.Troubleshooting/02.Update Failed/docs.en.md
+++ b/pages/03.Troubleshooting/02.Update Failed/docs.en.md
@@ -70,19 +70,7 @@ If there are any reported, firstly **ensure that you have a tested backup of you
 
     php bin/console doctrine:migration:migrate
 
-### 4. Check for database schema updates
-
-If your upgrade failed during the database update step, the database schema may not be up to date.  Run the following command to check for updates:
-
-    php bin/console doctrine:schema:update --dump-sql
-
-Running this command will tell you whether the database is up to date with the code.  If there are queries that need to be executed, **ensure you have a tested backup of your database before proceeding, as this command will cause changes to the database**, then run the following command:
-
-    php bin/console doctrine:schema:update --force
-
-If this hasn't resolved your problem, proceed to the next step.
-
-### 5. Try to update the files manually
+### 4. Try to update the files manually
 
 This step requires some manual intervention - there is no command for this part.
 


### PR DESCRIPTION
From the Symfony docs at https://symfony.com/doc/3.3/doctrine.html#creating-the-database-tables-schema:

> the doctrine:schema:update command should only be used during development. It should not be used in a production environment.

This section is causing trouble for users, especially those who upgraded from Mautic 2 to 3 and are having issues ([example](https://github.com/mautic/mautic/issues/9272)). We should remove this section from the docs.