### PR TITLE
Add documentation for disable export role permission 

### DIFF
--- a/pages/20.users-and-roles/02.managing-roles/docs.en.md
+++ b/pages/20.users-and-roles/02.managing-roles/docs.en.md
@@ -55,6 +55,10 @@ There are permission levels relating to resources the user has created themselve
 * Own - this allows the users with this role to view/edit/delete/publish their own resources in this part of Mautic, but not those created by others
 * Others - this allows the users with this role to view/edit/delete/publish their own resources in this part of Mautic, and those created by others
 
+Since the 3.2 release there is a permission level to prevent users from exporting resources:
+
+* Export Access - Select disable to prevent the users with this role from exporting resources from this part of Mautic
+
 There are permission levels relating to being able to manage resources:
 
 * Manage - this allows the users with this role to manage resources in this area of Mautic (for example, managing custom fields or plugins)


### PR DESCRIPTION
Documentation for https://github.com/mautic/mautic/pull/5995 which adds an option to disable exporting for contacts, forms and reports.