### PR TITLE
Update different callback URL for the Amazon SES API

### DIFF
--- a/pages/07.Channels/02.Emails/03.Bounce management/docs.en.md
+++ b/pages/07.Channels/02.Emails/03.Bounce management/docs.en.md
@@ -85,7 +85,11 @@ Mautic supports the bounce and complaint management from Amazon Simple Email Ser
 
 ![Topic](amazon_webhook_4.png "New subscriber")
 
-3. Enter the url to the Amazon webhook on your Mautic installation. It should usually be your Mautic URL followed by `/mailer/amazon/callback`.
+3. Enter the url to the Amazon webhook on your Mautic installation. 
+
+>>>>> When using the **SMTP method**, the callback URL will be your Mautic URL followed by `/mailer/amazon/callback`.
+>
+> When using the **API method** (available since Mautic 3.2), the callback URL will be your Mautic URL followed by `/mailer/amazon_api/callback`.
 
 ![Topic](amazon_webhook_5.png "Enter url to Mautic")
 


### PR DESCRIPTION
Since 3.2 when we introduced the Amazon SES API transport, there has been a separate callback URL that needs to be used when configuring the notifications.

This was never updated in the docs at the time 👿 

Added a note to show the two different callback URLs.