### PR TITLE
Fix heading alignment

### DIFF
--- a/themes/mauticdocs/css-compiled/theme.css
+++ b/themes/mauticdocs/css-compiled/theme.css
@@ -1198,12 +1198,14 @@ a:hover {
 h3 {
   font-family: "Muli", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
   font-weight: 400;
-  text-align: center;
+  text-align: left;
+  font-size: 1.3rem;
   font-size: 1.3rem;
 }
 
 h2 {
   font-size: 1.5rem;
+  text-align: left;
 }
 
 h1 {

--- a/themes/mauticdocs/scss/theme/_custom.scss
+++ b/themes/mauticdocs/scss/theme/_custom.scss
@@ -40,12 +40,13 @@ a {
 h3 {
   font-family: $font-family-default;
   font-weight: $font-weight-regular;
-  text-align: center;
+  text-align: left;
   font-size: 1.3rem;
 }
 
 h2 {
   font-size: 1.5rem;
+  text-align: left;
 }
 
 h1 {


### PR DESCRIPTION
This fixes the alignment for headings - we missed it with our theme customisations when deploying the child theme.