### PR TITLE
Update links for Github

### DIFF
--- a/themes/mauticdocs/mauticdocs.yaml
+++ b/themes/mauticdocs/mauticdocs.yaml
@@ -8,5 +8,5 @@ streams:
           - user/themes/learn2
 github:
     position: bottom                                   # top | bottom | off
-    tree: https://github.com/mautic/mautic-documentation/tree/main
-    commits: https://github.com/mautic/mautic-documentation/commits/main
+    tree: https://github.com/mautic/mautic-documentation/tree/main/
+    commits: https://github.com/mautic/mautic-documentation/commits/main/

--- a/themes/mauticdocs/mauticdocs.yaml
+++ b/themes/mauticdocs/mauticdocs.yaml
@@ -6,3 +6,7 @@ streams:
         '':
           - user/themes/mauticdocs
           - user/themes/learn2
+github:
+    position: bottom                                   # top | bottom | off
+    tree: https://github.com/mautic/mautic-documentation/tree/main
+    commits: https://github.com/mautic/mautic-documentation/commits/main


### PR DESCRIPTION
This should update the links at the bottom of the pages to use main rather than master for the branch name - it should be in the theme config file but I think it was hard-coded at a higher level in the past which is not editable in GitHub.