### PR TITLE
fix link to variable.html page

### DIFF
--- a/pages/03.Setup/06.Variables/docs.en.md
+++ b/pages/03.Setup/06.Variables/docs.en.md
@@ -249,5 +249,5 @@ See the [Search][search] page for more information.
 [custom-field]: </contacts/manage-fields>
 [make-pref-center]: </contacts/preference-center/customize-preference-center>
 [manage-emails]: </channels/emails/managing-emails>
-[manage-pages]: </components/pages/managing-pages>
+[manage-pages]: </components/landing-pages/managing-pages>
 [search]: </search>

--- a/pages/12.contacts/06.preference-center/01.customize-preference-center/docs.en.md
+++ b/pages/12.contacts/06.preference-center/01.customize-preference-center/docs.en.md
@@ -76,6 +76,6 @@ If no Preference Center page is selected in an email, the default page is displa
 
 ![default Preference Center page](unsubscribe.png)
 
-[variables]: <./../setup/VARIABLES.html>
+[variables]: <../../setup/variables.html>
 
 [pr7915]: <https://github.com/mautic/mautic/pull/7915>

--- a/pages/12.contacts/06.preference-center/01.customize-preference-center/docs.en.md
+++ b/pages/12.contacts/06.preference-center/01.customize-preference-center/docs.en.md
@@ -76,6 +76,6 @@ If no Preference Center page is selected in an email, the default page is displa
 
 ![default Preference Center page](unsubscribe.png)
 
-[variables]: <../../setup/variables.html>
+[variables]: </setup/variables>
 
 [pr7915]: <https://github.com/mautic/mautic/pull/7915>


### PR DESCRIPTION
Try to fix a link that today is redirecting to 404.

## Test the issue
1. Go to https://docs.mautic.org/en/contacts/preference-center/customize-preference-center
2. Click on any token/variable
3. See 404 because of URL not relatively correctly created

Apply patch and test again, i think it should fix the issue.