### PR TITLE
Fix Auth0 integration

### DIFF
--- a/plugins/login-oauth2-auth0/classes/Providers/Auth0Provider.php
+++ b/plugins/login-oauth2-auth0/classes/Providers/Auth0Provider.php
@@ -9,7 +9,7 @@ class Auth0Provider extends BaseProvider
     protected $name = 'Auth0';
     protected $classname = 'Riskio\\OAuth2\\Client\\Provider\\Auth0';
 
-    public function initProvider(array $options)
+    public function initProvider(array $options): void
     {
         $this->config = Grav::instance()['config'];
         $options += [


### PR DESCRIPTION
Currently, when navigating to https://docs.mautic.org/en/login and clicking "Mautic Community Login", the following error shows up:

![image](https://user-images.githubusercontent.com/17739158/141682722-ed37568a-8cfe-4307-b885-118709f5198c.png)

This PR should fix the issue (static analysis no longer throws errors in my testing), but I don't seem to have a way to run a local Grav instance easily.