### PR TITLE
Update docs.en.md

### DIFF
--- a/pages/05.Troubleshooting/04.file-ownership-and-permissions/docs.en.md
+++ b/pages/05.Troubleshooting/04.file-ownership-and-permissions/docs.en.md
@@ -76,7 +76,7 @@ If your file and folder permissions are incorrect, you can run the following com
 
 ```
 find . -type f -not -perm 644 -exec chmod 644 {} +
-find . -type d -not -perm 644 -exec chmod 755 {} +
+find . -type d -not -perm 755 -exec chmod 755 {} +
 chmod -R g+w var/cache/ var/logs/ app/config/
 chmod -R g+w media/files/ media/images/ translations/
 rm -rf var/cache/*


### PR DESCRIPTION
Looking for directories with permissions not 644 then changing them to 755 makes no sense.
It should be look for directories with permissions not 755 then change them to 755, the same logic as being done for the files, looks like a simple copy and paste typo.