### PR TITLE
Add explicit path to `sudo chown -R`

### DIFF
--- a/pages/05.Troubleshooting/04.file-ownership-and-permissions/docs.en.md
+++ b/pages/05.Troubleshooting/04.file-ownership-and-permissions/docs.en.md
@@ -96,7 +96,7 @@ If your files and folders are owned by the wrong user, you will continue to expe
 
 To reset the ownership of files and folders, use the following command (ensuring that you **replace apache_user and apache_group** with the values identified in the steps above):
 
-`sudo chown -R apache_user:apache_group`
+`sudo chown -R apache_user:apache_group /path/to/mautic`
 
 This command **ch**-anges **own**-ership, using the -R flag which means recursively - including all files/folders within that location. [Read more about the chown command][chown-command]
 


### PR DESCRIPTION
Given that it's possible a relatively novice user could end up on this page I feel it's important to have the path in the `chown` command. 

It's also best practice for something as potentially dangerous as `sudo chown -R` in case someone fat-fingers the command while scrolling their history and wipes out something important, like `/`.