### PR TITLE
Update composer docs translations

### DIFF
--- a/pages/03.Setup/01.how-to-install-mautic/03.Installing with Composer/docs.en.md
+++ b/pages/03.Setup/01.how-to-install-mautic/03.Installing with Composer/docs.en.md
@@ -33,7 +33,7 @@ The Mautic Recommended Project is a template which provides a starter kit for ma
 
 The basic command to use the Recommended Project is:
     
-    composer create-project mautic/recommended-project:4.x-dev some-dir --no-interaction
+    composer create-project mautic/recommended-project:^4 some-dir --no-interaction
 
 With composer require you can download new dependencies to your installation.
 

--- a/pages/03.Setup/03. How to switch to Composer/default.en.md
+++ b/pages/03.Setup/03. How to switch to Composer/default.en.md
@@ -37,7 +37,9 @@ Here's the steps to follow to switch to a Composer-based installation:
     - The entire `plugins` directory - move to `docroot/plugins`
     - Uploads - in most cases, located at `app/media/files` and `app/media/images` - move to `docroot/app/media/files` and `docroot/app/media/images` respectively
     - Custom dashboards from `app/media/dashboards` - move to `docroot/app/media/dashboards`
-    - Any custom themes from `themes` - move to `/docroot/themes`
+    - Any custom themes from `themes` - move to `/docroot/themes`     
+    - Any translations from `translations` - move to `/docroot/translations`
+
 1. Rename `/var/www/html` to `/var/www/html-old` and `/var/www/html-new` to `/var/www/html`
 1. When you're done, update your web server configuration to point to `/var/www/html/docroot` instead of `/var/www/html`
 1. You have now switched to a Composer-based installation. Test if Mautic works as expected.


### PR DESCRIPTION
We also need to move any existing translation files over when switching to Composer - these were missed from the original docs.