### PR TITLE
Fix broken link

### DIFF
--- a/pages/03.Setup/01.how-to-install-mautic/01. Installing from the production package/docs.en.md
+++ b/pages/03.Setup/01.how-to-install-mautic/01. Installing from the production package/docs.en.md
@@ -188,5 +188,5 @@ Install complete
 [download-mautic]: <https://www.mautic.org/download>
 [mautic-releases]: <https://www.mautic.org/mautic-releases>
 [minimum-requirements]: <https://www.mautic.org/download/requirements>
-[file-permissions]: <troubleshooting/file-ownership-and-permissions>
+[file-permissions]: </troubleshooting/file-ownership-and-permissions>
 [mailhog]: <https://github.com/mailhog/MailHog>


### PR DESCRIPTION
This should fix a 404 link from https://docs.mautic.org/en/setup/how-to-install-mautic/install-mautic-from-package with the correct route (https://docs.mautic.org/en/troubleshooting/file-ownership-and-permissions)